### PR TITLE
Align database and storage metadata with MediaWiki parity

### DIFF
--- a/docs/MEDIAWIKI_PARITY.md
+++ b/docs/MEDIAWIKI_PARITY.md
@@ -1,0 +1,40 @@
+# MediaWiki Parity Checklist
+
+This document captures how the Next.js wiki platform aligns with the upstream MediaWiki data model and storage conventions. Use it as a reference when validating migrations or when importing data from an existing MediaWiki instance.
+
+## Database Alignment
+
+| MediaWiki Table | Platform Model | Notes |
+| --- | --- | --- |
+| `page` | `Page` | Adds `page_random`, `page_len`, `page_touched`, `links_updated`, `content_model`, and `page_lang` to mirror MediaWiki metadata. `page_is_new` is tracked via `isNew`. |
+| `revision` | `Revision` | Stores parent pointers, SHA-1 hashes, byte lengths, content model/format, and comment references to match MediaWiki's revision metadata. |
+| `comment` | `Comment` | New table to store revision and media comments using MediaWiki's hash-based deduplication. |
+| `text` | `TextContent` | Supports MediaWiki-style compression flags for future parity with `old_flags`. |
+| `image` | `Media` | Tracks uploader name, current version, SHA-1, MIME metadata, and description comment references similar to `img_user_text`, `img_sha1`, and `img_description`. |
+| `oldimage` | `MediaArchive` | Already present; stores historic media versions with actor references. |
+| `categorylinks` | `PageCategory` | Maintains sort keys and MediaWiki-style prefix field. |
+| `pagelinks` | `PageLink` | Records from/to relationships for backlinks. |
+
+Additional indexes (`page_random`, `rev_sha1`, `uploaded_by_name`) match the MediaWiki schema so that operations such as `Special:Random`, revision deduplication, and user-specific media queries behave similarly.
+
+## Backend Behavior
+
+* Page creation and edits now generate MediaWiki-compatible comment rows, SHA-1 hashes, byte lengths, and parent revision pointers.
+* Page metadata updates keep `page_len`, `page_touched`, and `links_updated` synchronized with the latest revision, preserving expectations from maintenance scripts like `refreshLinks.php`.
+* Revision summaries are deduplicated via the `Comment` table exactly like MediaWiki, enabling clean imports from dumps that reference comment IDs.
+* Media revision updates run through the same TextContent/Comment flows so automated maintenance retains provenance and hashing metadata.
+
+## File Storage Parity
+
+* File uploads compute MediaWiki hash paths (`lib/storage/hash-path.ts`), populate SHA-1, MIME, and media type columns, and maintain `img_user_text` equivalents via `uploadedByName`.
+* Descriptions are normalized into the shared `Comment` table, matching the `img_description` / `comment` linkage in MediaWiki core.
+* Version counters increment on every upload (local or S3) to track the active version like MediaWiki's `img_major_mime`/`img_minor_mime` tables.
+* Archived versions retain metadata, uploader attribution, and SHA-1 to stay consistent with MediaWiki's `oldimage` records.
+
+## Operational Guidance
+
+1. Run `npx prisma generate` followed by your preferred migration command (`prisma migrate deploy` or `db push`) to apply the new schema changes.
+2. If importing MediaWiki dumps, map `page`, `revision`, `text`, and `comment` tables directly to the Prisma models described above. SHA-1, lengths, and comment hashes are stored verbatim.
+3. Ensure any upload pipeline passes through `lib/storage/index.ts` so uploader names, comments, and version counters stay synchronized.
+
+Keeping these components aligned ensures we can round-trip MediaWiki exports/imports and use familiar maintenance workflows without additional glue code.

--- a/prisma/migrations/20251008_mediawiki_parity.sql
+++ b/prisma/migrations/20251008_mediawiki_parity.sql
@@ -1,0 +1,60 @@
+-- MediaWiki Parity Alignment
+
+-- 1. Extend Page table with MediaWiki-compatible metadata
+ALTER TABLE "Page"
+  ADD COLUMN IF NOT EXISTS "is_new" BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS "page_random" DOUBLE PRECISION NOT NULL DEFAULT random(),
+  ADD COLUMN IF NOT EXISTS "page_touched" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "links_updated" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "page_len" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "content_model" TEXT NOT NULL DEFAULT 'wikitext',
+  ADD COLUMN IF NOT EXISTS "page_lang" TEXT;
+
+CREATE INDEX IF NOT EXISTS "Page_page_random_idx" ON "Page"("page_random");
+
+-- 2. Extend TextContent table to capture compression flags
+ALTER TABLE "TextContent"
+  ADD COLUMN IF NOT EXISTS "compression" TEXT;
+
+-- 3. Add Comment table (MediaWiki-style comment storage)
+CREATE TABLE IF NOT EXISTS "Comment" (
+  "id" TEXT PRIMARY KEY,
+  "text" TEXT NOT NULL,
+  "data" JSONB,
+  "hash" TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS "Comment_hash_idx" ON "Comment"("hash");
+
+-- 4. Update Revision table with MediaWiki metadata
+ALTER TABLE "Revision"
+  ADD COLUMN IF NOT EXISTS "parentRevisionId" TEXT,
+  ADD COLUMN IF NOT EXISTS "commentId" TEXT,
+  ADD COLUMN IF NOT EXISTS "rev_len" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS "rev_sha1" TEXT,
+  ADD COLUMN IF NOT EXISTS "rev_deleted" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS "content_model" TEXT NOT NULL DEFAULT 'wikitext',
+  ADD COLUMN IF NOT EXISTS "content_format" TEXT NOT NULL DEFAULT 'text/x-wiki';
+
+ALTER TABLE "Revision"
+  ADD CONSTRAINT IF NOT EXISTS "Revision_parentRevisionId_fkey"
+    FOREIGN KEY ("parentRevisionId") REFERENCES "Revision"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "Revision"
+  ADD CONSTRAINT IF NOT EXISTS "Revision_commentId_fkey"
+    FOREIGN KEY ("commentId") REFERENCES "Comment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX IF NOT EXISTS "Revision_rev_sha1_idx" ON "Revision"("rev_sha1");
+
+-- 5. Update Media table with additional MediaWiki fields
+ALTER TABLE "Media"
+  ADD COLUMN IF NOT EXISTS "uploaded_by_name" TEXT,
+  ADD COLUMN IF NOT EXISTS "current_version" INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS "description_id" TEXT;
+
+ALTER TABLE "Media"
+  ADD CONSTRAINT IF NOT EXISTS "Media_description_id_fkey"
+    FOREIGN KEY ("description_id") REFERENCES "Comment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Ensure supporting indexes exist
+CREATE INDEX IF NOT EXISTS "Media_uploaded_by_name_idx" ON "Media"("uploaded_by_name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,13 @@ model Page {
   latestRevisionId String?
   isRedirect       Boolean           @default(false)
   redirectTarget   String?
+  isNew            Boolean           @default(true) @map("is_new")
+  random           Float             @default(dbgenerated("random()")) @map("page_random")
+  touched          DateTime?         @map("page_touched")
+  linksUpdated     DateTime?         @map("links_updated")
+  length           Int               @default(0) @map("page_len")
+  contentModel     String            @default("wikitext") @map("content_model")
+  lang             String?           @map("page_lang")
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
   viewCount        Int               @default(0)
@@ -67,6 +74,7 @@ model Page {
   @@index([slug])
   @@index([namespaceId, title])
   @@index([updatedAt])
+  @@index([random])
 }
 
 model TextContent {
@@ -74,6 +82,7 @@ model TextContent {
   content   String
   sha1      String     @unique
   byteSize  Int
+  compression String?  @map("compression")
   revisions Revision[]
 
   @@index([sha1])
@@ -84,18 +93,40 @@ model Revision {
   pageId         String
   textId         String
   actorId        String
+  parentRevisionId String?
+  commentId      String?
   summary        String?        @db.VarChar(500)
   revisionNumber Int
   timestamp      DateTime       @default(now())
   isMinor        Boolean        @default(false)
+  byteSize       Int            @default(0) @map("rev_len")
+  sha1           String?        @map("rev_sha1")
+  deleted        Boolean        @default(false) @map("rev_deleted")
+  contentModel   String         @default("wikitext") @map("content_model")
+  contentFormat  String         @default("text/x-wiki") @map("content_format")
   recentChanges  RecentChange[]
   actor          Actor          @relation(fields: [actorId], references: [id])
   page           Page           @relation(fields: [pageId], references: [id], onDelete: Cascade)
   textContent    TextContent    @relation(fields: [textId], references: [id])
+  parentRevision Revision?      @relation("RevisionParent", fields: [parentRevisionId], references: [id])
+  childRevisions Revision[]     @relation("RevisionParent")
+  comment        Comment?       @relation("RevisionComment", fields: [commentId], references: [id])
 
   @@unique([pageId, revisionNumber])
   @@index([pageId, timestamp])
   @@index([timestamp])
+  @@index([sha1])
+}
+
+model Comment {
+  id        String    @id @default(cuid())
+  text      String
+  data      Json?
+  hash      String    @unique
+  revisions Revision[] @relation("RevisionComment")
+  media     Media[]   @relation("MediaDescription")
+
+  @@index([hash])
 }
 
 model Namespace {
@@ -204,9 +235,12 @@ model Media {
   archiveName   String?         @map("archive_name")
   deleted       Int             @default(0)
   descriptionId String?         @map("description_id")
+  uploadedByName String?        @map("uploaded_by_name")
+  currentVersion Int            @default(1) @map("current_version")
   uploadedAt    DateTime        @default(now()) @map("timestamp")
   uploadedById  String?
   uploadedBy    User?           @relation("MediaUploader", fields: [uploadedById], references: [id])
+  description   Comment?        @relation("MediaDescription", fields: [descriptionId], references: [id])
   archives      MediaArchive[]
   categories    MediaCategory[]
   revisions     MediaRevision[]
@@ -218,6 +252,7 @@ model Media {
   @@index([mediaType])
   @@index([majorMime])
   @@index([uploadedById])
+  @@index([uploadedByName])
 }
 
 model MediaArchive {


### PR DESCRIPTION
## Summary
- extend the Prisma schema with MediaWiki-style metadata, random indexes, and a shared comment table for revisions and media
- update wiki and media services to populate SHA-1 hashes, byte lengths, parent pointers, uploader names, and description comments so backend behavior mirrors MediaWiki
- document the MediaWiki parity guarantees and add a migration to bring existing databases up to date

## Testing
- npm run lint *(fails: repository already contains numerous lint errors about existing any usage and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d48f863483208a2b572f7a84282a